### PR TITLE
Changed how cells in a record is selected

### DIFF
--- a/src/CsvHelper.Excel/ExcelParser.cs
+++ b/src/CsvHelper.Excel/ExcelParser.cs
@@ -23,6 +23,8 @@ namespace CsvHelper.Excel
         private int _rawRow = 1;
         private string[] _currentRecord;
         private readonly int _lastRow;
+        private readonly int _firstColumn;
+        private readonly int _lastColumn;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExcelParser"/> class.
@@ -118,8 +120,9 @@ namespace CsvHelper.Excel
                 _lastRow = lastRowUsed.RowNumber();
 
                 var cellsUsed = _worksheet.CellsUsed();
-                Count = cellsUsed.Max(c => c.Address.ColumnNumber) -
-                    cellsUsed.Min(c => c.Address.ColumnNumber) + 1;
+                _firstColumn = cellsUsed.Min(c => c.Address.ColumnNumber);
+                _lastColumn = cellsUsed.Max(c => c.Address.ColumnNumber);
+                Count = _lastColumn - _firstColumn + 1;
             }
 
             Context = new CsvContext(this);
@@ -204,7 +207,7 @@ namespace CsvHelper.Excel
         private string[] GetRecord()
         {
             var currentRow = _worksheet.Row(Row);
-            var cells = currentRow.Cells(1, Count);
+            var cells = currentRow.Cells(_firstColumn, _lastColumn);
             var values = Configuration.TrimOptions.HasFlag(TrimOptions.Trim)
                 ? cells.Select(x => x.Value.ToString()?.Trim()).ToArray()
                 : cells.Select(x => x.Value.ToString()).ToArray();


### PR DESCRIPTION
I had an issue reading an excel file recently because the table I was trying to read started at column B instead of A. 
This meant that while the count of columns was right, e.g. 10, the cells being selected was wrong i.e. from 1 to 10, instead of from 2 to 11.

The change below allows the table to start anywhere in the sheet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youngcm2/CsvHelper.Excel/40)
<!-- Reviewable:end -->
