### PR TITLE
Fix ExcelParser ignoring the requested Culture (BREAKING CHANGE)

### DIFF
--- a/src/CsvHelper.Excel/ExcelParser.cs
+++ b/src/CsvHelper.Excel/ExcelParser.cs
@@ -206,8 +206,8 @@ namespace CsvHelper.Excel
             var currentRow = _worksheet.Row(Row);
             var cells = currentRow.Cells(1, Count);
             var values = Configuration.TrimOptions.HasFlag(TrimOptions.Trim)
-                ? cells.Select(x => x.Value.ToString()?.Trim()).ToArray()
-                : cells.Select(x => x.Value.ToString()).ToArray();
+                ? cells.Select(x => x.Value.ToString(Configuration.CultureInfo)?.Trim()).ToArray()
+                : cells.Select(x => x.Value.ToString(Configuration.CultureInfo)).ToArray();
 
             return values;
         }


### PR DESCRIPTION
Note: This fix may cause breaking behaviours as previously the culture conversion was ignored. ExcelParser defaulted to an InvariantCulture in the constructor but actually defaulted to the user's CurrentCulture during parsing. If a specific culture was specified during construction or in the CsvConfiguration, this was also ignored during parsing.

Cause: XLCellValue.ToString() defaults to the user's current culture unless a specific culture is supplied as an optional parameter. This fix passes the Configuration.CultureInfo to the XLCellValue.ToString() to ensure the requested culture is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youngcm2/CsvHelper.Excel/49)
<!-- Reviewable:end -->
