### PR TITLE
Update NuGet packages and alter code to work with CsvHelper v33

### DIFF
--- a/src/CsvHelper.Excel.Specs/Common/Helpers.cs
+++ b/src/CsvHelper.Excel.Specs/Common/Helpers.cs
@@ -9,12 +9,12 @@ namespace CsvHelper.Excel.Specs.Common
         {
             if (!File.Exists(path))
             {
-                var workbook = new XLWorkbook(XLEventTracking.Disabled);
+                var workbook = new XLWorkbook();
                 workbook.GetOrAddWorksheet(worksheetName);
                 workbook.SaveAs(path);
                 return workbook;
             }
-            return new XLWorkbook(path, XLEventTracking.Disabled);
+            return new XLWorkbook(path);
         }
 
         public static IXLWorksheet GetOrAddWorksheet(this XLWorkbook workbook, string sheetName)

--- a/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
+++ b/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.4" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
-    <PackageReference Include="FluentAssertions" Version="6.3.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
-    <PackageReference Include="System.Linq.Async" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="ClosedXML" Version="0.102.3" />
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.11.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CsvHelper.Excel.Specs/Parser/ExcelParserAsyncSpec.cs
+++ b/src/CsvHelper.Excel.Specs/Parser/ExcelParserAsyncSpec.cs
@@ -94,21 +94,21 @@ namespace CsvHelper.Excel.Specs.Parser
         }
         
         [Fact]
-        public async void TheResultsAreNotNull()
+        public async Task TheResultsAreNotNull()
         {
             await RunAsync();
             Results.Should().NotBeNull();
         }
 
         [Fact]
-        public async void TheResultsAreCorrect()
+        public async Task TheResultsAreCorrect()
         {
             await RunAsync();
             Values.Should().BeEquivalentTo(Results, options => options.IncludingProperties());
         }
 
         [Fact]
-        public async void RowsHaveData()
+        public async Task RowsHaveData()
         {
             var csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {

--- a/src/CsvHelper.Excel.Specs/Parser/ExcelParserAsyncSpec.cs
+++ b/src/CsvHelper.Excel.Specs/Parser/ExcelParserAsyncSpec.cs
@@ -83,7 +83,7 @@ namespace CsvHelper.Excel.Specs.Parser
         {
             var csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                ShouldSkipRecord = record => record.Record.All(string.IsNullOrEmpty)
+                ShouldSkipRecord = args => args.Row.Parser.Record?.All(string.IsNullOrWhiteSpace) ?? false,
             };
             using var parser = new ExcelParser(Path, WorksheetName, csvConfiguration);
             using var reader = new CsvReader(parser);
@@ -112,7 +112,7 @@ namespace CsvHelper.Excel.Specs.Parser
         {
             var csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                ShouldSkipRecord = record => record.Record.All(string.IsNullOrEmpty)
+                ShouldSkipRecord = args => args.Row.Parser.Record?.All(string.IsNullOrWhiteSpace) ?? false,
             };
             using var parser = new ExcelParser(Path, WorksheetName, csvConfiguration );
             using var reader = new CsvReader(parser);

--- a/src/CsvHelper.Excel.Specs/Parser/ParseUsingPathSpecWithBlankRow.cs
+++ b/src/CsvHelper.Excel.Specs/Parser/ParseUsingPathSpecWithBlankRow.cs
@@ -10,7 +10,7 @@ namespace CsvHelper.Excel.Specs.Parser
         {
             var csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                ShouldSkipRecord = record => record.Record.All(string.IsNullOrEmpty)
+                ShouldSkipRecord = args => args.Row.Parser.Record?.All(string.IsNullOrWhiteSpace) ?? false,
             };
             using var parser = new ExcelParser(Path, null, csvConfiguration);
             Run(parser);

--- a/src/CsvHelper.Excel/CsvHelper.Excel.csproj
+++ b/src/CsvHelper.Excel/CsvHelper.Excel.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An implementation of ICsvParser and ICsvSerializer from CsvHelper that reads and writes using the ClosedXml library.</Description>
     <AssemblyTitle>CsvHelper for Excel</AssemblyTitle>
-    <VersionPrefix>27.2.1</VersionPrefix>    
+    <VersionPrefix>33.0.0</VersionPrefix>    
     <Authors>Chris Young</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
@@ -15,8 +15,8 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup> 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.4" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
+    <PackageReference Include="ClosedXML" Version="0.102.3" />
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
   </ItemGroup>
 </Project>

--- a/src/CsvHelper.Excel/ExcelParser.cs
+++ b/src/CsvHelper.Excel/ExcelParser.cs
@@ -115,7 +115,7 @@ namespace CsvHelper.Excel
         /// <param name="sheetName">The sheet name</param>
         /// <param name="configuration">The configuration.</param>
         /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelParser"/> object is disposed, otherwise <c>false</c>.</param>
-        public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration, bool leaveOpen = false)
+        public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration, bool leaveOpen)
         {
             var workbook = new XLWorkbook(stream);
 
@@ -134,7 +134,6 @@ namespace CsvHelper.Excel
             }
 
             Context = new CsvContext(this);
-            //_leaveOpen = Configuration.LeaveOpen; //removed in CsvHelper 30.0.0 > The LeaveOpen value is now passed directly via constructor for the parser and writer:
             _leaveOpen = leaveOpen;
         }
 

--- a/src/CsvHelper.Excel/ExcelParser.cs
+++ b/src/CsvHelper.Excel/ExcelParser.cs
@@ -104,6 +104,16 @@ namespace CsvHelper.Excel
         /// <param name="stream">The stream.</param>
         /// <param name="sheetName">The sheet name</param>
         /// <param name="configuration">The configuration.</param>
+        public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration) : this(stream, sheetName, configuration, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExcelParser"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="sheetName">The sheet name</param>
+        /// <param name="configuration">The configuration.</param>
         /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelParser"/> object is disposed, otherwise <c>false</c>.</param>
         public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration, bool leaveOpen = false)
         {

--- a/src/CsvHelper.Excel/ExcelParser.cs
+++ b/src/CsvHelper.Excel/ExcelParser.cs
@@ -83,7 +83,7 @@ namespace CsvHelper.Excel
         /// <param name="culture">The culture.</param>
         /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelParser"/> object is disposed, otherwise <c>false</c>.</param>
         public ExcelParser(Stream stream, string sheetName, CultureInfo culture, bool leaveOpen = false) : this(stream,
-            sheetName, new CsvConfiguration(culture) {LeaveOpen= leaveOpen})
+            sheetName, new CsvConfiguration(culture), leaveOpen)
         {
         }
 
@@ -104,9 +104,10 @@ namespace CsvHelper.Excel
         /// <param name="stream">The stream.</param>
         /// <param name="sheetName">The sheet name</param>
         /// <param name="configuration">The configuration.</param>
-        public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration)
+        /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelParser"/> object is disposed, otherwise <c>false</c>.</param>
+        public ExcelParser(Stream stream, string sheetName, CsvConfiguration configuration, bool leaveOpen = false)
         {
-            var workbook = new XLWorkbook(stream, XLEventTracking.Disabled);
+            var workbook = new XLWorkbook(stream);
 
             _worksheet = string.IsNullOrEmpty(sheetName) ? workbook.Worksheet(1) : workbook.Worksheet(sheetName);
 
@@ -123,7 +124,8 @@ namespace CsvHelper.Excel
             }
 
             Context = new CsvContext(this);
-            _leaveOpen = Configuration.LeaveOpen;
+            //_leaveOpen = Configuration.LeaveOpen; //removed in CsvHelper 30.0.0 > The LeaveOpen value is now passed directly via constructor for the parser and writer:
+            _leaveOpen = leaveOpen;
         }
 
 

--- a/src/CsvHelper.Excel/ExcelWriter.cs
+++ b/src/CsvHelper.Excel/ExcelWriter.cs
@@ -2,7 +2,9 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+
 using ClosedXML.Excel;
+
 using CsvHelper.Configuration;
 
 #pragma warning disable 649
@@ -16,7 +18,6 @@ namespace CsvHelper.Excel
     public class ExcelWriter : CsvWriter
     {
         private readonly bool _leaveOpen;
-        private readonly bool _sanitizeForInjection;
 
         private bool _disposed;
         private int _row = 1;
@@ -86,9 +87,9 @@ namespace CsvHelper.Excel
         /// <param name="culture">The culture.</param>
         /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelWriter"/> object is disposed, otherwise <c>false</c>.</param>
         public ExcelWriter(Stream stream, string sheetName, CultureInfo culture, bool leaveOpen = false) : this(stream,
-            sheetName, new CsvConfiguration(culture) { LeaveOpen = leaveOpen })
+            sheetName, new CsvConfiguration(culture), leaveOpen)
         {
-            
+
         }
 
         /// <summary>
@@ -97,22 +98,23 @@ namespace CsvHelper.Excel
         /// <param name="stream">The stream.</param>
         /// <param name="sheetName">The sheet name</param>
         /// <param name="configuration">The configuration.</param>
-        private ExcelWriter(Stream stream, string sheetName, CsvConfiguration configuration) : base(TextWriter.Null,
+        /// <param name="leaveOpen"><c>true</c> to leave the <see cref="TextWriter"/> open after the <see cref="ExcelWriter"/> object is disposed, otherwise <c>false</c>.</param>
+
+        private ExcelWriter(Stream stream, string sheetName, CsvConfiguration configuration, bool leaveOpen = false) : base(TextWriter.Null,
             configuration)
         {
             configuration.Validate();
-            _worksheet = new XLWorkbook(XLEventTracking.Disabled).AddWorksheet(sheetName);
+            _worksheet = new XLWorkbook().AddWorksheet(sheetName);
             this._stream = stream;
 
-            _leaveOpen = configuration.LeaveOpen;
-            _sanitizeForInjection = configuration.SanitizeForInjection;
+            _leaveOpen = leaveOpen;
         }
 
 
         /// <inheritdoc/>
         public override void WriteField(string field, bool shouldQuote)
         {
-            if (_sanitizeForInjection)
+            if (Configuration.InjectionOptions != InjectionOptions.None)
             {
                 field = SanitizeForInjection(field);
             }


### PR DESCRIPTION
CsvHelper.Excel:
CsvHelper to 33.0.1
ClosedXML to 0.102.3
DocumentFormat.OpenXml to 2.20.0

CsvHelper.Excel.Specs:
CsvHelper to 33.0.1
ClosedXML to 0.102.3
DocumentFormat.OpenXml to 2.20.0
FluentAssertions to 6.12.1
Microsoft.Bcl.AsyncInterfaces to 8.0.0
Microsoft.NET.Test.Sdk to 17.11.1
Microsoft.TestPlatform.ObjectModel to 17.11.1
System.Linq.Async to 6.0.1
xunit to 2.9.0
xunit.runner.visualstudio to 2.8.2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youngcm2/CsvHelper.Excel/52)
<!-- Reviewable:end -->
